### PR TITLE
[Feat/#1] 라우트 연결과 sidebar UI 제작

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,29 @@
-import React from "react";
+import { Route, Routes, useNavigate, useLocation } from "react-router-dom";
+import { useEffect, useState, useRef } from "react";
+import SideBar from "components/SideBar";
 
 const App = () => {
-  return <div>hello</div>;
+  const nav = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.pathname.split("/")[1] === "managecar") nav("/car");
+  }, []);
+
+  return (
+    <>
+      <div className="w-full min-h-screen bg-slate-50">
+        {/* 사이드바 */}
+        <SideBar />
+        {/* 메인 컨텐츠 */}
+        <Routes>
+          <Route path="/resvcheck" element={<div>resvcheck</div>}></Route>
+          <Route path="/map" element={<div>map</div>}></Route>
+          <Route path="/returnkey" element={<div>returnkey</div>}></Route>
+        </Routes>
+      </div>
+    </>
+  );
 };
 
 export default App;

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -1,0 +1,85 @@
+import Logo from "assets/Logo.png";
+import { useNavigate } from "react-router-dom";
+import { useEffect, useState, useRef } from "react";
+import { MdVpnKey, MdEventAvailable, MdLocalParking } from "react-icons/md";
+import { useRecoilState } from "recoil";
+import { pageSelector } from "recoil/selectedPageAtom";
+
+const SideBar = () => {
+  const [rclIsClicked, setRclIsClicked] = useRecoilState(pageSelector);
+
+  useEffect(() => {
+    console.log(rclIsClicked);
+    console.log(menu);
+  }, [rclIsClicked]);
+
+  const clickedStyle =
+    "w-[400px] h-[60px] px-4 mt-3 rounded-2xl bg-slate-400 flex items-center text-slate-800";
+
+  const nav = useNavigate(); // nav 제어
+  const [menu, setMenu] = useState([
+    {
+      name: "예약 번호",
+      icon: <MdEventAvailable className="text-[40px]" />,
+      path: "/resvcheck",
+    },
+    {
+      name: "주차장 보기",
+      icon: <MdLocalParking className="text-[40px]" />,
+      path: "/map",
+    },
+    {
+      name: "키 반납",
+      icon: <MdVpnKey className="text-[40px]" />,
+      path: "/returnkey",
+    },
+  ]); // 각 메뉴 + 아이콘
+  return (
+    <>
+      <div className="fixed left-0 w-[500px] h-screen bg-blue-100 flex flex-col items-center">
+        {/* 로고 */}
+        <div className="w-[500px] flex justify-center">
+          <img src={Logo} alt="로고" className="w-[200px] m-5" />
+        </div>
+        {/* 지점 이름 */}
+        <div className="w-[500px] justify-center flex text-5xl font-bold text-blue-800 my-4">
+          서울대 지점
+        </div>
+        {/* 메뉴들 + 로그아웃 버튼 */}
+        <div className="w-[450px] h-[600px] rounded-2xl bg-slate-50 my-4 flex flex-col justify-between items-center">
+          <div className="w-[420px]">
+            {menu.map((v, i) => {
+              return (
+                <button
+                  key={i}
+                  className={
+                    rclIsClicked[i]
+                      ? clickedStyle
+                      : "w-[400px] h-[60px] px-4 mt-3 rounded-2xl hover:bg-slate-400 flex items-center hover:text-slate-800"
+                  }
+                  onClick={() => {
+                    setRclIsClicked(i);
+                    nav(v["path"]); // 지정된 경로로 이동
+                  }}
+                >
+                  {v["icon"]}
+                  <div className="text-[30px] font-bold ml-12">{v["name"]}</div>
+                </button>
+              );
+            })}
+          </div>
+        </div>{" "}
+        <button
+          className="w-[450px] h-[70px] mb-4 flex justify-center items-center bg-sky-200 rounded-2xl text-3xl font-extrabold hover:shadow-figma"
+          onClick={() => {
+            // set to admin mode
+          }}
+        >
+          관리자 모드
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default SideBar;

--- a/src/recoil/selectedPageAtom.js
+++ b/src/recoil/selectedPageAtom.js
@@ -1,0 +1,16 @@
+const { atom, selector } = require("recoil");
+
+export const selectedPageAtom = atom({
+  key: "selectedPageAtom",
+  default: [true, false, false],
+});
+
+export const pageSelector = selector({
+  key: "pageSelector",
+  get: ({ get }) => get(selectedPageAtom),
+  set: ({ set }, newValue) => {
+    const temp = [false, false, false];
+    temp[newValue] = true;
+    set(selectedPageAtom, temp);
+  },
+});


### PR DESCRIPTION


<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

키오스크 페이지를 만들기에 앞서

리액트 라우터를 사용하여 라우트를 연결하고 항상 왼쪽에 존재하는 사이드바의 UI 구현

<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents

### route 연결

``` js
<div className="w-full min-h-screen bg-slate-50">
  {/* 사이드바 */}
  <SideBar />
  {/* 메인 컨텐츠 */}
  <Routes>
    <Route path="/resvcheck" element={<div>resvcheck</div>}></Route>
    <Route path="/map" element={<div>map</div>}></Route>
    <Route path="/returnkey" element={<div>returnkey</div>}></Route>
  </Routes>
</div>
```

- 사이드바는 항상 왼쪽에 떠있으므로 Routes 밖에 존재

<br>

### SideBar 컴포넌트 구현

``` js
const nav = useNavigate(); // nav 제어

onClick={() => {
  setRclIsClicked(i);
  nav(v["path"]); // 지정된 경로로 이동
}}
```
- SideBar에서 메뉴를 클릭 할 경우 그 페이지로 이동해야 한다.
- useNavigate를 통해 클릭한 메뉴에 해당하는 페이지로 이동시킨다.

<br>

### 선택된 페이지를 표시하기 위한 selectedPageAtom을 추가
``` js
export const selectedPageAtom = atom({
  key: "selectedPageAtom",
  default: [true, false, false],
});

export const pageSelector = selector({
  key: "pageSelector",
  get: ({ get }) => get(selectedPageAtom),
  set: ({ set }, newValue) => {
    const temp = [false, false, false];
    temp[newValue] = true;
    set(selectedPageAtom, temp);
  },
});

```

- SideBar 컴포넌트 내부에서 State를 통해 현재 선택된 메뉴에 계속 표시가 되게 만들려 했으나, 페이지 이동으로 인해서인지 리렌더링이 원활하게 되지 않았음.
- 이로 인해 recoil atom을 제작하여 사용하게 됨

``` js
<button
  key={i}
  className={
    rclIsClicked[i]
      ? clickedStyle
      : "w-[400px] h-[60px] px-4 mt-3 rounded-2xl hover:bg-slate-400 flex items-center hover:text-slate-800"
  }
  onClick={() => {
    setRclIsClicked(i);
    nav(v["path"]); // 지정된 경로로 이동
  }}
>
  {v["icon"]}
  <div className="text-[30px] font-bold ml-12">{v["name"]}</div>
</button>
```

- 선택된 페이지에는 항상 표시가 되도록 하기 위해 recoil state를 통해 스타일을 바꿔주었음

<br>

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 현재 선택한 페이지가 계속 표시됨
- [x] 사이드바를 클릭하여 페이지 이동 가능

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

### 사이드바를 통한 링크 이동

![sidebar](https://github.com/YU-RentCar/yurentcar-fe-kiosk/assets/54520200/19f60858-4662-43cc-92d5-0a9c99324f69)

<br>

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

- #1 

close #1 

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
