### PR TITLE
[Fix/#19] 사이드바와 페이지가 맞지않던 버그 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import { kioskLocationAtom } from "recoil/kioskLocationAtom";
 import Alert from "popUp/Alert";
 import { useAlert } from "utils/useAlert";
 import { alertAtom } from "recoil/alertAtom";
+import { pageSelector } from "recoil/selectedPageAtom";
 
 const App = () => {
   const nav = useNavigate();
@@ -25,6 +26,8 @@ const App = () => {
   const [rclKioskId, setRclKioskId] = useRecoilState(kioskIdAtom);
   const [rclKioskLocation, setRclKioskLocation] =
     useRecoilState(kioskLocationAtom);
+
+  const [rclSelectedPage, setRclSelectedPage] = useRecoilState(pageSelector);
 
   const [input, setInput] = useState("");
 
@@ -118,8 +121,10 @@ const App = () => {
                 </h1>
                 <button
                   onClick={() => {
+                    setRclSelectedPage(0);
+                    nav("/resvcheck");
                     setIsInitialPage(false);
-                    setCounter(10);
+                    setCounter(240);
                   }}
                   className="w-1/4 py-10 mt-[50px] bg-blue-300 rounded-md text-4xl font-bold"
                 >

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -13,7 +13,7 @@ const SideBar = () => {
   const rclKioskLocation = useRecoilValue(kioskLocationAtom);
 
   const clickedStyle =
-    "w-[400px] h-[60px] px-4 mt-3 rounded-2xl bg-slate-400 flex items-center text-slate-800";
+    "w-[400px] my-8 h-[80px] px-4 mt-3 rounded-2xl bg-slate-400 flex items-center text-slate-800 transition-all";
 
   const nav = useNavigate(); // nav 제어
   const [menu, setMenu] = useState([
@@ -65,7 +65,7 @@ const SideBar = () => {
                   className={
                     rclIsClicked[i]
                       ? clickedStyle
-                      : "w-[400px] h-[60px] px-4 mt-3 rounded-2xl hover:bg-slate-400 flex items-center hover:text-slate-800"
+                      : "w-[400px] my-8 h-[60px] px-4 mt-3 rounded-2xl hover:bg-slate-400 flex items-center hover:text-slate-800"
                   }
                   onClick={() => {
                     setRclIsClicked(i);
@@ -79,14 +79,6 @@ const SideBar = () => {
             })}
           </div>
         </div>{" "}
-        <button
-          className="w-[450px] h-[70px] mb-4 flex justify-center items-center bg-sky-200 rounded-2xl text-3xl font-extrabold hover:shadow-figma"
-          onClick={() => {
-            // set to admin mode
-          }}
-        >
-          관리자 모드
-        </button>
       </div>
     </div>
   );


### PR DESCRIPTION

<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

사이드바와 페이지가 맞지않던 버그 수정


## 🥥 Contents

### 사이드바와 페이지가 맞지않던 버그 수정

``` js
<button
  onClick={() => {
    setRclSelectedPage(0);
    nav("/resvcheck");
    setIsInitialPage(false);
    setCounter(240);
  }}
  className="...">
  사용하기
</button>
```

- 사용하기 버튼을 누르면 nav를 "/resvcheck" 로 강제로 변경하여 진입하게 함
- 선택된 페이지를 0번으로 고정시켜 사이드바와 일치시킴

<br>

### 관리자 모드 버튼 삭제
삭제.

<br>

### transition-all 속성 사이드바 UI에 추가

<br>


## 🧪 Testing

- [x] 사이드바와 페이지가 맞지않던 버그 수정
- [x] transition-all 속성 사이드바 UI에 추가
- [x] 관리자 모드 버튼 삭제

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

![sidebar](https://github.com/YU-RentCar/yurentcar-fe-kiosk/assets/54520200/ce31b3f9-b002-4c0f-9bb3-a91a0de35e8e)


<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

- #19 

close #19 

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
